### PR TITLE
Don't create a new connection after an event 'closed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ look like:
 {
   host: 'localhost',
   port: 61613,
+  retryOnClosed:true,
   heartbeat: {
     client: 5000,
     broker: 5000,
@@ -145,3 +146,7 @@ client.on('lateheartbeat', function (frame) {
   //do something...
 });
 ```
+
+###closed
+Occurs when the broken closed the connection. By default, a new connection is created, but you can disable this, with the property 'retryOnClosed' and set it to false. It will only try one time.
+

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var _ = require('lodash'),
 var defaultConfig = {
   host: 'localhost',
   port: 61613,
+  retryOnClosed:true,
   heartbeat: {
     client: 5000,
     broker: 5000,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -37,7 +37,9 @@ Client.prototype.createNewTransport = function (config, connectedCallback) {
 
   transport.on('closed', function () {
     console.warn('Transport closed.');
-    this.transport = this.createNewTransport(this.config);
+    if (_.has(this.config,'retryOnClosed') && this.config.retryOnClosed === true) {
+      this.transport = this.createNewTransport(this.config);
+    }
   }.bind(this));
 
   transport.on('error', function (err) {


### PR DESCRIPTION
Add a new property 'retryOnClosed' to be able to try only once to communicate with broker if the connection was closed, because sometimes, we don't want to try again and again if the connection was previously closed (for exemple, when using a bad port ... it's the origin of this PR).

I just had a new property in the configuration and keep the same behavior by default, but the retry can be disable easily now.