### PR TITLE
Emit an transportClosed event and don't reconnect in nextBufferedMessage

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -38,7 +38,7 @@ Client.prototype.createNewTransport = function (config, connectedCallback) {
   }.bind(this));
 
   transport.on('closed', function () {
-    console.warn('Transport closed.');
+    this.emit('transportClosed');
     if (_.has(this.config,'retryOnClosed') && this.config.retryOnClosed === true) {
       this.transport = this.createNewTransport(this.config);
     }
@@ -140,8 +140,10 @@ Client.prototype.nextBufferedMessage = function () {
   if (this.transport && this.transport.connected()) {
     var message = this.bufferedMessages.splice(0,1)[0];
     if (message) this.transport.send(message);
-  } else {
-    this.transport = this.createNewTransport(this.config);
+  } 
+else {
+ //   console.log("nextBufferedMessage");
+ //   this.transport = this.createNewTransport(this.config);
   }
 };
 


### PR DESCRIPTION
Hi Chris,

When using retryOnClosed:false, there is currently no event to tell you about disconnections so I have added an emit of transportClose. Also when it does disconnect, it tries to repeatedly reconnect (every 50ms) due to nextBufferedMessage creating a new Transport if it was disconnected. 

Hope you are well, Tom